### PR TITLE
Link to new content from get started page

### DIFF
--- a/src/views/getting-started.njk
+++ b/src/views/getting-started.njk
@@ -36,11 +36,21 @@
         <h2 class="govuk-heading-m govuk-!-padding-top-6">1. Check if GOV.UK Sign In is right for you</h2>
 
         <p class="govuk-body">
-          GOV.UK Sign In is for central government services that need authentication.
+          You can read:
         </p>
 
-        <p class="govuk-body">You will also need to have development expertise in your team.</p>
-        <p class="govuk-body"><a class="govuk-link" href="/features">See the features GOV.UK Sign In currently offers.</a></p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            about the <a class="govuk-link" href="/features">features GOV.UK Sign In currently offers</a>
+          </li>
+          <li>
+            our <a class="govuk-link" href="/features/roadmap">roadmap</a>
+          </li>
+          <li>
+            our <a class="govuk-link" href="/documentation">documentation</a> on how to integrate GOV.UK Sign In with your service
+          </li>
+        </ul>
+
       </div>
     </div>
 
@@ -77,25 +87,20 @@
         <h2 class="govuk-heading-m govuk-!-padding-top-6">3. Test GOV.UK Sign In</h2>
 
         <p class="govuk-body">
-          If your service needs authentication and you work in central government, we’ll give you access to our test environment (or ‘sandbox’). You’ll be able to integrate your service to see how it works for yourself.
+          We'll give you access to our test environment (or 'sandbox') if your service:
         </p>
-
-        <p class="govuk-body">We’ll also send you information including:</p>
 
         <ul class="govuk-list govuk-list--bullet">
           <li>
-            our current timescales
+            is a central government service
           </li>
           <li>
-            GOV.UK Sign In user journey maps
-          </li>
-          <li>
-            suggested design patterns for linking your user journey to GOV.UK Sign In
+            needs your users to be able to sign in with a username and password
           </li>
         </ul>
 
         <p class="govuk-body">
-          You can request to join our private beta if you think GOV.UK Sign In is right for you.
+          Once in the test environment, you’ll be able to integrate with GOV.UK Sign to see for yourself how it works.
         </p>
        </div>
     </div>
@@ -105,11 +110,11 @@
         <h2 class="govuk-heading-m govuk-!-padding-top-6">4. Join private beta and go live</h2>
 
         <p class="govuk-body">
-          Once you’ve been accepted into the private beta, you’ll need to sign our memorandum of understanding.
+          After you’ve integrated with the test environment, you can request to join our private beta if GOV.UK Sign In is right for you.
         </p>
 
         <p class="govuk-body">
-          You can then go live with support from our technical team, who will be available 24/7 for urgent incidents.
+          <a class="govuk-link" href="/getting-started/private-beta">Read more about private beta</a> including the eligibility criteria and what to expect if you join. 
         </p>
       </div>
     </div>


### PR DESCRIPTION
This is to link from the 'Get started' page to the new content we've published recently. This includes the features, roadmap, documentation and private beta pages. 