### PR TITLE
Say tech docs now include identity

### DIFF
--- a/src/views/documentation.njk
+++ b/src/views/documentation.njk
@@ -49,11 +49,18 @@
         <p class="govuk-body">Our technical documentation will help you:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>understand how GOV.UK Sign In works</li>
-          <li>integrate with GOV.UK Sign In’s test environment</li>
+          <li>integrate with GOV.UK Sign In’s test environment for authentication</li>
         </ul>
-        <div class="govuk-inset-text">
-          The documentation does not include information about identity checks. It covers the authentication part of GOV.UK Sign In that lets users sign into your service with a username and password.
-        </div>
+        <p class="govuk-body">
+          The documentation covers both the authentication and identity checking parts of GOV.UK Sign In. 
+        </p>
+        <p class="govuk-body">
+          Only the authentication part is available to all central government services now.  
+        </p>
+        <p class="govuk-body">
+          We’ve included information about identity checks because this feature is being tested by selected services. It will also let all services see how our identity checks work.   
+        </p>
+        
         <p class="govuk-body">
           <a class="govuk-link" href="https://docs.sign-in.service.gov.uk" rel="noreferrer noopener" target="_blank">Read our technical documentation (opens in new tab)</a>
         </p>


### PR DESCRIPTION
We've published the identity parts of the tech docs, so we need to change the content where we said they were auth only. 