### PR TITLE
SSE-2987 product pages deployment workflow

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -3,7 +3,7 @@ name: Publish Product pages to AWS (Dev)
 on:
   workflow_dispatch:
   push:
-    # branches: [ main ]
+    branches: [ main ]
 
 permissions: read-all
 

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,0 +1,24 @@
+name: Publish Product pages to AWS (Dev)
+
+on:
+  workflow_dispatch:
+  push:
+    # branches: [ main ]
+
+permissions: read-all
+
+jobs:
+  build-frontend:
+    name: Build Frontend
+    uses: ./.github/workflows/build.yml
+
+  deploy-frontend:
+    name: Deploy Frontend
+    needs: [ build-frontend ]
+    uses: ./.github/workflows/upload-frontend.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      environment: development-secure-pipelines
+      artifact-name: ${{ needs.build-frontend.outputs.artifact-name || inputs.frontend-artifact }}

--- a/.github/workflows/upload-frontend.yml
+++ b/.github/workflows/upload-frontend.yml
@@ -1,0 +1,38 @@
+name: Upload Frontend to secure pipelines
+
+on:
+  workflow_call:
+    inputs:
+      environment: { required: true, type: string }
+      artifact-name: { required: true, type: string }
+
+concurrency: deploy-product-frontend-secure-pipelines-${{ inputs.environment }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ steps.deploy.outputs.pipeline-url }}
+
+    steps:
+      - name: Deploy Product
+        id: deploy-product
+        uses: alphagov/di-github-actions/secure-pipelines/deploy-fargate@407381405d22479808a226de506ad19ba22fd3f5
+        timeout-minutes: 20
+        with:
+          aws-role-arn: ${{ vars.PRODUCT_PAGES_FRONTEND_DEPLOYMENT_ROLE_ARN }}
+          artifact-bucket-name: ${{ vars.PRODUCT_PAGES_FRONTEND_ARTIFACT_SOURCE_BUCKET_NAME }}
+          container-signing-key-arn: ${{ vars.PRODUCT_PAGES_CONTAINER_SIGNING_KEY_ARN }}
+          ecr-repository: ${{ vars.PRODUCT_PAGES_FRONTEND_ECR_REPOSITORY_NAME }}
+          pipeline-name: ${{ vars.PRODUCT_PAGES_FRONTEND_PIPELINE_NAME }}
+          dockerfile: Dockerfile
+          template: infrastructure/frontend/frontend.template.yml
+          artifact-name: ${{ inputs.artifact-name }}
+          artifact-path: express/dist

--- a/.github/workflows/upload-frontend.yml
+++ b/.github/workflows/upload-frontend.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Deploy Product
         id: deploy-product
-        uses: alphagov/di-github-actions/secure-pipelines/deploy-fargate@407381405d22479808a226de506ad19ba22fd3f5
+        uses: govuk-one-login/github-actions/secure-pipelines/deploy-fargate@407381405d22479808a226de506ad19ba22fd3f5
         timeout-minutes: 20
         with:
           aws-role-arn: ${{ vars.PRODUCT_PAGES_FRONTEND_DEPLOYMENT_ROLE_ARN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# checkov:skip=CKV_DOCKER_7: Ensure the base image uses a non latest version tag
+# checkov:skip=CKV_DOCKER_2: Ensure that HEALTHCHECK instructions have been added to container images
+# checkov:skip=CKV_DOCKER_3: Ensure that a user for the container has been created
 # Use an official Node.js runtime as a parent image
 FROM node:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Use an official Node.js runtime as a parent image
+FROM node:latest
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the package.json and package-lock.json files to the container
+COPY *.json ./
+
+# Install project dependencies
+ENV PUPPETEER_SKIP_DOWNLOAD true
+RUN apt-get update && apt-get install -y chromium
+RUN npm install
+
+# Copy the .env.example file to .env
+COPY .env.example .env
+
+# Copy the rest of your application code to the container
+COPY . .
+
+# Expose any necessary ports (if your application requires it)
+# EXPOSE 3000
+
+# Define the command to run your application
+CMD [ "npm", "run", "local" ]

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -1,11 +1,10 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: DI Product Tool frontend
+Description: DI Self-service Product Pages frontend
 Transform: AWS::LanguageExtensions
 
 Parameters:
   ImageURI:
     Type: String
-    Default: "494650018671.dkr.ecr.eu-west-2.amazonaws.com/self-service/frontend:64f1f66e9e18532faccc3c1fcf127dc57cb8044b"
     Description: The URI of the ECR image to use for the container
   ContainerPort:
     Type: Number
@@ -70,10 +69,10 @@ Resources:
       ExecutionRoleArn: !GetAtt ExecutionRole.Arn
       Cpu: 256
       Memory: 1024
-      Family: !Sub ${DeploymentName}-product
+      Family: !Sub ${DeploymentName}-productpages-frontend
       NetworkMode: awsvpc
       ContainerDefinitions:
-        - Name: self-service-product
+        - Name: productpages-frontend
           Image: !Ref ImageURI
           ReadonlyRootFilesystem: false
           Environment:
@@ -85,18 +84,6 @@ Resources:
               Value: !Ref GoogleTagID
             - Name: SESSION_SECRET
               Value: "{{resolve:secretsmanager:/self-service/frontend/session-secret}}"
-            #- Name: SESSIONS_TABLE
-              #Value:
-                #Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-SessionsTableName
-            #- Name: API_BASE_URL
-              #Value:
-                #Fn::ImportValue: !Sub ${DeploymentName}-API-BaseURL
-            #- Name: COGNITO_USER_POOL_ID
-              #Value:
-                #Fn::ImportValue: !Sub ${DeploymentName}-Cognito-UserPoolID
-            #- Name: COGNITO_CLIENT_ID
-              #Value:
-                #Fn::ImportValue: !Sub ${DeploymentName}-Cognito-UserPoolClientID
             - Name: DT_LOGLEVELCON
               Value: INFO
           PortMappings:
@@ -165,43 +152,11 @@ Resources:
             Condition:
               ArnLike:
                 aws:SourceArn: !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:*
-      #Policies:
-        # https://github.com/ca98am79/connect-dynamodb#iam-permissions
-        #- PolicyName: SessionStorageTable
-          #PolicyDocument:
-            #Version: 2012-10-17
-            #Statement:
-              #- Effect: Allow
-                #Action:
-                  #- dynamodb:Scan
-                  #- dynamodb:GetItem
-                  #- dynamodb:PutItem
-                  #- dynamodb:UpdateItem
-                  #- dynamodb:DeleteItem
-                  #- dynamodb:DescribeTable
-                #Resource:
-                  #Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-SessionsTableARN
-        #- PolicyName: Cognito
-          #PolicyDocument:
-            #Version: 2012-10-17
-            #Statement:
-              #- Effect: Allow
-                #Action:
-                  #- cognito-idp:AdminCreateUser
-                  #- cognito-idp:AdminInitiateAuth
-                  #- cognito-idp:AdminUpdateUserAttributes
-                  #- cognito-idp:AdminSetUserMFAPreference
-                  #- cognito-idp:AdminRespondToAuthChallenge
-                  #- cognito-idp:AdminGetUser
-                  #- cognito-idp:AddCustomAttributes
-                  #- cognito-idp:UpdateUserPoolClient
-                #Resource:
-                  #Fn::ImportValue: !Sub ${DeploymentName}-Cognito-UserPoolARN
-
+ 
   FargateCluster:
     Type: AWS::ECS::Cluster
     Properties:
-      ClusterName: !Sub ${DeploymentName}-product
+      ClusterName: !Sub ${DeploymentName}-productpages-frontend
       ClusterSettings:
         - Name: containerInsights
           Value: enabled
@@ -210,14 +165,14 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: ApplicationLoadBalancerListener
     Properties:
-      ServiceName: self-service-product
+      ServiceName: productpages-frontend
       Cluster: !GetAtt FargateCluster.Arn
       TaskDefinition: !Ref TaskDefinition
       PropagateTags: SERVICE
       LaunchType: FARGATE
       DesiredCount: 1
       LoadBalancers:
-        - ContainerName: self-service-product
+        - ContainerName: productpages-frontend
           ContainerPort: !Ref ContainerPort
           TargetGroupArn: !Ref ApplicationTargetGroup
       NetworkConfiguration:
@@ -229,7 +184,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !ImportValue VPC-ID
-      GroupDescription: Frontend container service access
+      GroupDescription: Product Pages Frontend container service access
       SecurityGroupIngress:
         - Description: Allow traffic from the application load balancer
           SourceSecurityGroupId: !GetAtt ApplicationSecurityGroup.GroupId
@@ -238,7 +193,7 @@ Resources:
           ToPort: !Ref ContainerPort
       Tags:
         - Key: Name
-          Value: !Sub ${DeploymentName}-frontend-container-service-product
+          Value: !Sub ${DeploymentName}-frontend-container-service-productpages
 
   #--- Application load balancing ---#
 
@@ -247,7 +202,7 @@ Resources:
     Properties:
       Type: application
       Scheme: internet-facing
-      Name: !Sub ${DeploymentName}-app-product
+      Name: !Sub ${DeploymentName}-app-productpages
       Subnets: !Split [ ",", !ImportValue VPC-InternetSubnets ]
       SecurityGroups: [ !Ref ApplicationSecurityGroup ]
       LoadBalancerAttributes:
@@ -267,7 +222,7 @@ Resources:
       LoadBalancerArn: !Ref ApplicationLoadBalancer
       Certificates:
         - CertificateArn:
-            Fn::ImportValue: !If [ Subdomain, DNS-SubdomainCertificateARN, DNS-CertificateARN ]
+            Fn::ImportValue: !If [ Subdomain, DNS-SubdomainCertificateARN, DNS-SubdomainCertificateARN ]
       DefaultActions:
         - TargetGroupArn: !Ref ApplicationTargetGroup
           Type: forward
@@ -275,7 +230,7 @@ Resources:
   ApplicationTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: !Sub ${DeploymentName}-ecs-product
+      Name: !Sub ${DeploymentName}-ecs-productpages
       VpcId: !ImportValue VPC-ID
       Port: !Ref ContainerPort
       Protocol: HTTP
@@ -285,7 +240,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !ImportValue VPC-ID
-      GroupDescription: Frontend application load balancer
+      GroupDescription: Product Pages Frontend application load balancer
       SecurityGroupIngress:
         - Description: Allow secure traffic from the internet
           CidrIp: 0.0.0.0/0     # Any IPv4 address
@@ -294,7 +249,7 @@ Resources:
           ToPort: 443
       Tags:
         - Key: Name
-          Value: !Sub ${DeploymentName}-frontend-application-load-balancer-product
+          Value: !Sub ${DeploymentName}-frontend-application-load-balancer-productpages
 
   ApplicationSecurityGroupEgress:
     Type: AWS::EC2::SecurityGroupEgress
@@ -631,7 +586,7 @@ Resources:
     Properties:
       Type: A
       Name: !Sub
-        - product.${Domain}
+        - productpages.${Name}${Domain}
         - Name: !If [ Subdomain, !Sub "${DeploymentName}.", ""]
           Domain: !ImportValue DNS-Domain
       HostedZoneId: !ImportValue DNS-HostedZoneID

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -1,0 +1,665 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: DI Product Tool frontend
+Transform: AWS::LanguageExtensions
+
+Parameters:
+  ImageURI:
+    Type: String
+    Default: "494650018671.dkr.ecr.eu-west-2.amazonaws.com/self-service/frontend:64f1f66e9e18532faccc3c1fcf127dc57cb8044b"
+    Description: The URI of the ECR image to use for the container
+  ContainerPort:
+    Type: Number
+    Default: 3000
+  LogGroupPrefix:
+    Type: String
+    AllowedPattern: ^.*[^\/]$
+    Default: /aws/vendedlogs
+  DeploymentName:
+    Type: String
+    MaxLength: 28
+    AllowedPattern: ^.*[^-]$
+    Default: self-service
+    Description: A unique prefix to identify the deployment; used when importing or exporting values from related stacks
+  ShowTestBanner:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /self-service/frontend/show-test-banner
+  GoogleTagID:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /self-service/frontend/google-tag-id
+  PermissionsBoundary:
+    Type: String
+    Default: ""
+    Description: The ARN of the permissions boundary to apply when creating IAM roles
+  Environment:
+    Description: "The name of the environment to deploy to."
+    Type: "String"
+    Default: dev
+    AllowedValues:
+      - "dev"
+      - "build"
+      - "staging"
+      - "integration"
+      - "production"
+
+Mappings:
+  # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
+  ElasticLoadBalancer:
+    eu-west-2:
+      AccountID: 652711504416
+  TxMAAccountARN:
+    Environment:
+      dev: 'arn:aws:iam::494650018671:root'
+      build: 'arn:aws:iam::399055180839:root'
+      staging: 'arn:aws:iam::178023842775:root'
+      integration: 'arn:aws:iam::729485541398:root'
+      production: 'arn:aws:iam::451773080033:root'
+
+Conditions:
+  Subdomain: !Not [ !Equals [ !Ref DeploymentName, self-service ] ]
+  UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundary, "" ] ]
+
+Resources:
+
+  #--- Fargate / ECS ---#
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      RequiresCompatibilities: [ FARGATE ]
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      Cpu: 256
+      Memory: 1024
+      Family: !Sub ${DeploymentName}-product
+      NetworkMode: awsvpc
+      ContainerDefinitions:
+        - Name: self-service-product
+          Image: !Ref ImageURI
+          ReadonlyRootFilesystem: false
+          Environment:
+            - Name: PORT
+              Value: !Ref ContainerPort
+            - Name: TEST_BANNER
+              Value: !Ref ShowTestBanner
+            - Name: GOOGLE_TAG_ID
+              Value: !Ref GoogleTagID
+            - Name: SESSION_SECRET
+              Value: "{{resolve:secretsmanager:/self-service/frontend/session-secret}}"
+            #- Name: SESSIONS_TABLE
+              #Value:
+                #Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-SessionsTableName
+            #- Name: API_BASE_URL
+              #Value:
+                #Fn::ImportValue: !Sub ${DeploymentName}-API-BaseURL
+            #- Name: COGNITO_USER_POOL_ID
+              #Value:
+                #Fn::ImportValue: !Sub ${DeploymentName}-Cognito-UserPoolID
+            #- Name: COGNITO_CLIENT_ID
+              #Value:
+                #Fn::ImportValue: !Sub ${DeploymentName}-Cognito-UserPoolClientID
+            - Name: DT_LOGLEVELCON
+              Value: INFO
+          PortMappings:
+            - ContainerPort: !Ref ContainerPort
+          HealthCheck:
+            Command: [ "CMD", "wget", "--spider", !Sub "http://localhost:${ContainerPort}" ]
+          LogConfiguration:
+            # https://docs.docker.com/config/containers/logging/awslogs/
+            LogDriver: awslogs
+            Options:
+              # Consider lines not starting with whitespace as a multi-line log message boundary
+              awslogs-multiline-pattern: ^[^\s}]+.*$
+              awslogs-group: !Sub ${LogGroupPrefix}/${DeploymentName}/frontend
+              awslogs-stream-prefix: ecs
+              awslogs-create-group: true
+              awslogs-region: !Ref AWS::Region
+
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: Grant the Fargate and ECS container agents permissions to make AWS API calls and access ECR
+      PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
+      ManagedPolicyArns: [ arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy ]
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+      Policies:
+        - PolicyName: CreateLogGroup
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: logs:CreateLogGroup
+                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LogGroupPrefix}/${DeploymentName}/frontend*
+        - PolicyName: GetDynatraceSecret
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource: arn:aws:secretsmanager:eu-west-2:216552277552:secret:*
+              - Effect: Allow
+                Action: secretsmanager:ListSecrets
+                Resource: arn:aws:secretsmanager:eu-west-2:216552277552:secret:*
+              - Effect: Allow
+                Action: kms:Decrypt
+                Resource: arn:aws:kms:eu-west-2:216552277552:key/*
+
+
+
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: Allow the Frontend application tasks to access AWS services
+      PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: [ ecs-tasks.amazonaws.com ]
+            Condition:
+              ArnLike:
+                aws:SourceArn: !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:*
+      #Policies:
+        # https://github.com/ca98am79/connect-dynamodb#iam-permissions
+        #- PolicyName: SessionStorageTable
+          #PolicyDocument:
+            #Version: 2012-10-17
+            #Statement:
+              #- Effect: Allow
+                #Action:
+                  #- dynamodb:Scan
+                  #- dynamodb:GetItem
+                  #- dynamodb:PutItem
+                  #- dynamodb:UpdateItem
+                  #- dynamodb:DeleteItem
+                  #- dynamodb:DescribeTable
+                #Resource:
+                  #Fn::ImportValue: !Sub ${DeploymentName}-DynamoDB-SessionsTableARN
+        #- PolicyName: Cognito
+          #PolicyDocument:
+            #Version: 2012-10-17
+            #Statement:
+              #- Effect: Allow
+                #Action:
+                  #- cognito-idp:AdminCreateUser
+                  #- cognito-idp:AdminInitiateAuth
+                  #- cognito-idp:AdminUpdateUserAttributes
+                  #- cognito-idp:AdminSetUserMFAPreference
+                  #- cognito-idp:AdminRespondToAuthChallenge
+                  #- cognito-idp:AdminGetUser
+                  #- cognito-idp:AddCustomAttributes
+                  #- cognito-idp:UpdateUserPoolClient
+                #Resource:
+                  #Fn::ImportValue: !Sub ${DeploymentName}-Cognito-UserPoolARN
+
+  FargateCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub ${DeploymentName}-product
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+
+  ContainerService:
+    Type: AWS::ECS::Service
+    DependsOn: ApplicationLoadBalancerListener
+    Properties:
+      ServiceName: self-service-product
+      Cluster: !GetAtt FargateCluster.Arn
+      TaskDefinition: !Ref TaskDefinition
+      PropagateTags: SERVICE
+      LaunchType: FARGATE
+      DesiredCount: 1
+      LoadBalancers:
+        - ContainerName: self-service-product
+          ContainerPort: !Ref ContainerPort
+          TargetGroupArn: !Ref ApplicationTargetGroup
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          Subnets: !Split [ ",", !ImportValue VPC-ProtectedSubnets ]
+          SecurityGroups: [ !GetAtt ContainerServiceSecurityGroup.GroupId ]
+
+  ContainerServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !ImportValue VPC-ID
+      GroupDescription: Frontend container service access
+      SecurityGroupIngress:
+        - Description: Allow traffic from the application load balancer
+          SourceSecurityGroupId: !GetAtt ApplicationSecurityGroup.GroupId
+          IpProtocol: tcp
+          FromPort: !Ref ContainerPort
+          ToPort: !Ref ContainerPort
+      Tags:
+        - Key: Name
+          Value: !Sub ${DeploymentName}-frontend-container-service-product
+
+  #--- Application load balancing ---#
+
+  ApplicationLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Type: application
+      Scheme: internet-facing
+      Name: !Sub ${DeploymentName}-app-product
+      Subnets: !Split [ ",", !ImportValue VPC-InternetSubnets ]
+      SecurityGroups: [ !Ref ApplicationSecurityGroup ]
+      LoadBalancerAttributes:
+        - Key: routing.http.drop_invalid_header_fields.enabled
+          Value: true
+        - Key: access_logs.s3.enabled
+          Value: true
+        - Key: access_logs.s3.bucket
+          Value: !ImportValue ELB-AccessLogsBucket
+
+  ApplicationLoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      Port: 443
+      Protocol: HTTPS
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      LoadBalancerArn: !Ref ApplicationLoadBalancer
+      Certificates:
+        - CertificateArn:
+            Fn::ImportValue: !If [ Subdomain, DNS-SubdomainCertificateARN, DNS-CertificateARN ]
+      DefaultActions:
+        - TargetGroupArn: !Ref ApplicationTargetGroup
+          Type: forward
+
+  ApplicationTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub ${DeploymentName}-ecs-product
+      VpcId: !ImportValue VPC-ID
+      Port: !Ref ContainerPort
+      Protocol: HTTP
+      TargetType: ip
+
+  ApplicationSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !ImportValue VPC-ID
+      GroupDescription: Frontend application load balancer
+      SecurityGroupIngress:
+        - Description: Allow secure traffic from the internet
+          CidrIp: 0.0.0.0/0     # Any IPv4 address
+          IpProtocol: tcp
+          FromPort: 443         # HTTPS
+          ToPort: 443
+      Tags:
+        - Key: Name
+          Value: !Sub ${DeploymentName}-frontend-application-load-balancer-product
+
+  ApplicationSecurityGroupEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !GetAtt ApplicationSecurityGroup.GroupId
+      Description: Allow traffic to the frontend container service
+      DestinationSecurityGroupId: !GetAtt ContainerServiceSecurityGroup.GroupId
+      IpProtocol: tcp
+      FromPort: !Ref ContainerPort
+      ToPort: !Ref ContainerPort
+
+  #--- Logging ---#
+
+  AccessLogsBucket:
+    # checkov:skip=CKV_AWS_18:Ensure the S3 bucket has access logging enabled
+    # checkov:skip=CKV_AWS_21:Ensure the S3 bucket has versioning enabled
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub
+        - ${DeploymentName}-application-access-logs-${ID}
+        - ID: !Select [ 0, !Split [ "-", !Select [ 2, !Split [ "/", !Ref AWS::StackId ] ] ] ]
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
+  AccessLogsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref AccessLogsBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: s3:PutObject
+            Resource: !Sub ${AccessLogsBucket.Arn}/AWSLogs/${AWS::AccountId}/*
+            Principal:
+              AWS: !FindInMap [ ElasticLoadBalancer, !Ref AWS::Region, AccountID ]
+
+  TxMASQSProducerAuditEventQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 1209600 # 14 days in seconds
+      QueueName: !Sub '${AWS::StackName}-AuditEventQueue'
+      KmsMasterKeyId: !Ref TxMASQSProducerAuditEventQueueEncryptionKeyAlias
+      RedriveAllowPolicy:
+        redrivePermission: denyAll
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt TxMAAuditEventDeadLetterQueue.Arn
+        maxReceiveCount: 10
+      Tags:
+        - Key: 'AuthoredBy'
+          Value: 'TxMA'
+        - Key: 'ProducerType'
+          Value: 'SQS'
+
+  TxMASQSProducerAuditEventQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref TxMASQSProducerAuditEventQueue
+      PolicyDocument:
+        Statement:
+          - Sid: 'AllowReadByTxMAAccount'
+            Effect: Allow
+            Principal:
+              AWS: !FindInMap [ TxMAAccountARN, Environment, !Ref 'Environment' ]
+            Action:
+              - 'sqs:ChangeMessageVisibility'
+              - 'sqs:ReceiveMessage'
+              - 'sqs:DeleteMessage'
+              - 'sqs:GetQueueAttributes'
+            Resource: !GetAtt TxMASQSProducerAuditEventQueue.Arn
+
+  TxMASQSAllowQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref TxMASQSProducerAuditEventQueue
+      PolicyDocument:
+        Statement:
+          - Sid: 'AllowAccessToAdmin'
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action:
+              - 'sqs:ChangeMessageVisibility'
+              - 'sqs:ReceiveMessage'
+              - 'sqs:DeleteMessage'
+              - 'sqs:GetQueueAttributes'
+              - 'sqs:SendMessage'
+              - 'sqs:GetQueueUrl'
+            Resource: !GetAtt TxMASQSProducerAuditEventQueue.Arn
+
+  TxMAAuditEventDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 1209600 # 14 days in seconds
+      QueueName: !Sub '${AWS::StackName}-AuditEventDeadLetterQueue'
+      KmsMasterKeyId: !Ref TxMASQSProducerAuditEventQueueEncryptionKeyAlias
+      Tags:
+        - Key: 'AuthoredBy'
+          Value: 'TxMA'
+        - Key: 'ProducerType'
+          Value: 'SQS'
+
+  TxMASQSProducerAuditEventQueueEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Symmetric key used to encrypt TxMA audit messages at rest in SQS
+      EnableKeyRotation: true
+      KeySpec: SYMMETRIC_DEFAULT
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: 'Enable root account access'
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action:
+              - 'kms:*'
+            Resource: '*'
+          - Sid: 'Allow Lambda Access'
+            Effect: Allow
+            Principal:
+              Service: 'lambda.amazonaws.com'
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt
+              - kms:GenerateDataKey
+            Resource: '*'
+          - Sid: 'Allow decryption of events by TxMA'
+            Effect: Allow
+            Principal:
+              AWS: !FindInMap [ TxMAAccountARN, Environment, !Ref 'Environment' ]
+            Action:
+              - 'kms:decrypt'
+            Resource: '*'
+      Tags:
+        - Key: 'AuthoredBy'
+          Value: 'TxMA'
+        - Key: 'ProducerType'
+          Value: 'SQS'
+
+  TxMASQSProducerAuditEventQueueEncryptionKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub alias/${AWS::StackName}/AuditEventEncryptionKey
+      TargetKeyId: !Ref TxMASQSProducerAuditEventQueueEncryptionKey
+
+  KMSARNParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${AWS::StackName}/KMSARN'
+      Type: String
+      Value: !Sub '${TxMASQSProducerAuditEventQueueEncryptionKey.Arn}'
+      Description: ARN of the KMS key used for encryption.
+      Tags:
+        AuthoredBy: TxMA
+        ProducerType: SQS
+
+  SQSQueueARNParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${AWS::StackName}/QueueARN'
+      Type: String
+      Value: !Sub '${TxMASQSProducerAuditEventQueue.Arn}'
+      Description: ARN of the queue to submit events to.
+      Tags:
+        AuthoredBy: TxMA
+        ProducerType: SQS
+
+  SQSQueueNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${AWS::StackName}/QueueName'
+      Type: String
+      Value: !Sub '${TxMASQSProducerAuditEventQueue.QueueName}'
+      Description: Name of the queue to submit events to.
+      Tags:
+        AuthoredBy: TxMA
+        ProducerType: SQS
+
+  SQSQueueURLParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${AWS::StackName}/QueueURL'
+      Type: String
+      Value: !Sub '${TxMASQSProducerAuditEventQueue.QueueUrl}'
+      Description: URL of the queue to submit events to.
+      Tags:
+        AuthoredBy: TxMA
+        ProducerType: SQS
+
+  FrontendWebAcl:
+    Type: 'AWS::WAFv2::WebACL'
+    Properties:
+      Name: !Sub '${AWS::StackName}-${Environment}-acl'
+      Scope: REGIONAL
+      Description: Web ACL for Application Load Balancer
+      DefaultAction:
+        Allow:
+          CustomRequestHandling:
+            InsertHeaders:
+              - Name: info
+                Value: waf-allowed
+      VisibilityConfig:
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName: !Sub '${AWS::StackName}-${Environment}-metric'
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-${Environment}'
+      Rules:
+        - Name: AWS-CRS
+          Priority: 0
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+              ExcludedRules:
+                - Name: CrossSiteScripting_BODY
+                - Name: CrossSiteScripting_COOKIE
+                - Name: CrossSiteScripting_QUERYARGUMENTS
+                - Name: CrossSiteScripting_URIPATH
+                - Name: EC2MetaDataSSRF_BODY
+                - Name: EC2MetaDataSSRF_COOKIE
+                - Name: EC2MetaDataSSRF_QUERYARGUMENTS
+                - Name: EC2MetaDataSSRF_URIPATH
+                - Name: GenericLFI_BODY
+                - Name: GenericLFI_QUERYARGUMENTS
+                - Name: GenericLFI_URIPATH
+                - Name: GenericRFI_BODY
+                - Name: GenericRFI_QUERYARGUMENTS
+                - Name: GenericRFI_URIPATH
+                - Name: NoUserAgent_HEADER
+                - Name: RestrictedExtensions_QUERYARGUMENTS
+                - Name: RestrictedExtensions_URIPATH
+                - Name: SizeRestrictions_BODY
+                - Name: SizeRestrictions_Cookie_HEADER
+                - Name: SizeRestrictions_QUERYSTRING
+                - Name: SizeRestrictions_URIPATH
+                - Name: UserAgent_BadBots_HEADER
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Sub '${AWS::StackName}-${Environment}-aws-crs-metric'
+        - Name: Bad-Inputs
+          Priority: 1
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesKnownBadInputsRuleSet
+              ExcludedRules:
+                - Name: ExploitablePaths_URIPATH
+                - Name: Host_localhost_HEADER
+                - Name: JavaDeserializationRCE_BODY
+                - Name: JavaDeserializationRCE_HEADER
+                - Name: JavaDeserializationRCE_QUERYSTRING
+                - Name: JavaDeserializationRCE_URIPATH
+                # - Name: Log4JRCE
+                - Name: PROPFIND_METHOD
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Sub '${AWS::StackName}-${Environment}-bad-inputs-metric'
+        - Name: Anonymous-IpList
+          Priority: 2
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesAnonymousIpList
+              ExcludedRules:
+                - Name: AnonymousIPList
+                - Name: HostingProviderIPList
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Sub '${AWS::StackName}-${Environment}-anonymous-iplist-metric'
+        - Name: SQLInject-RuleSet
+          Priority: 3
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesSQLiRuleSet
+              ExcludedRules:
+                - Name: SQLiExtendedPatterns_QUERYARGUMENTS
+                - Name: SQLi_BODY
+                - Name: SQLi_COOKIE
+                - Name: SQLi_QUERYARGUMENTS
+                - Name: SQLi_URIPATH
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Sub '${AWS::StackName}-${Environment}-SQLinjection-ruleset-metric'
+        - Name: RateBased-CountIpRule
+          Priority: 4
+          Statement:
+            RateBasedStatement:
+              Limit: 100
+              AggregateKeyType: IP
+          Action:
+            Count: { }
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: !Sub "${AWS::StackName}-${Environment}-RateBased-CountIp-ruleset-metric"
+            SampledRequestsEnabled: true
+
+  FrontendWebACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn: !Sub
+        - '${ResourceArn}'
+        - ResourceArn: !Ref ApplicationLoadBalancer
+      WebACLArn: !Sub
+        - '${WebACLArn}'
+        - WebACLArn: !GetAtt FrontendWebAcl.Arn
+
+  #--- DNS ---#
+
+  DNSRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Type: A
+      Name: !Sub
+        - product.${Domain}
+        - Name: !If [ Subdomain, !Sub "${DeploymentName}.", ""]
+          Domain: !ImportValue DNS-Domain
+      HostedZoneId: !ImportValue DNS-HostedZoneID
+      AliasTarget:
+        DNSName: !GetAtt ApplicationLoadBalancer.DNSName
+        HostedZoneId: !GetAtt ApplicationLoadBalancer.CanonicalHostedZoneID
+        EvaluateTargetHealth: false
+
+Outputs:
+  AdminToolURL:
+    Value: !Sub https://${DNSRecord}
+  KMSARN:
+    Description: 'ARN of the KMS key used for encryption.'
+    Value: !Sub '${TxMASQSProducerAuditEventQueueEncryptionKey.Arn}'
+    Export:
+      Name: !Sub '${AWS::StackName}-KMSARN'
+  QueueARN:
+    Description: 'ARN of the queue to submit events to.'
+    Value: !Sub '${TxMASQSProducerAuditEventQueue.Arn}'
+    Export:
+      Name: !Sub '${AWS::StackName}-QueueARN'
+  QueueName:
+    Description: 'Name of the queue to submit events to.'
+    Value: !Sub '${TxMASQSProducerAuditEventQueue.QueueName}'
+    Export:
+      Name: !Sub '${AWS::StackName}-QueueName'
+  QueueURL:
+    Description: 'URL of the queue to submit events to.'
+    Value: !Sub '${TxMASQSProducerAuditEventQueue.QueueUrl}'
+    Export:
+      Name: !Sub '${AWS::StackName}-QueueURL'


### PR DESCRIPTION
# Code Changes
-  Updated GitHub env vars for development pipeline
- Trigger dev pipeline on push to main
- create publish to dev workflow
   - [upload-frontend.yml](https://github.com/govuk-one-login/onboarding-product-page/blob/SSE-2987-deploy-workflow/.github/workflows/upload-frontend.yml)
  - [publish-dev.yml](https://github.com/govuk-one-login/onboarding-product-page/blob/SSE-2987-deploy-workflow/.github/workflows/publish-dev.yml)
- [Dockerfile](https://github.com/govuk-one-login/onboarding-product-page/blob/SSE-2987-deploy-workflow/Dockerfile)
- [frontend.template.yml](https://github.com/govuk-one-login/onboarding-product-page/blob/SSE-2987-deploy-workflow/infrastructure/frontend/frontend.template.yml)

# Why
- secure pipelines for Product pages (PaaS removal)
- workflow to support the moving of Product Pages off PaaS