### PR TITLE
SSE-3110: Explicit log group creation with Data Protection Policy

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -37,7 +37,7 @@ jobs:
       template: infrastructure/frontend/frontend.template.yml
       parameters: |
         ImageURI=${{ needs.push-frontend-image.outputs.image-uri }}
-        LogGroupPrefix=/self-service/preview
+        LogGroupPrefix=/self-service/product-pages/preview
 
   run-acceptance-tests:
     name: Run tests

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -34,4 +34,4 @@ jobs:
       template: infrastructure/frontend/frontend.template.yml
       parameters: |
         ImageURI=${{ needs.push-frontend-image.outputs.image-uri }}
-        LogGroupPrefix=/self-service/preview
+        LogGroupPrefix=/self-service/product-pages/preview

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -12,7 +12,7 @@ Parameters:
   LogGroupPrefix:
     Type: String
     AllowedPattern: ^.*[^\/]$
-    Default: /aws/vendedlogs
+    Default: /self-service/product-pages
   DeploymentName:
     Type: String
     MaxLength: 25
@@ -127,10 +127,56 @@ Resources:
             Options:
               # Consider lines not starting with whitespace as a multi-line log message boundary
               awslogs-multiline-pattern: ^[^\s}]+.*$
-              awslogs-group: !Sub ${LogGroupPrefix}/${DeploymentName}/frontend
+              awslogs-group: !Ref FrontendLogsGroup
               awslogs-stream-prefix: ecs
-              awslogs-create-group: true
               awslogs-region: !Ref AWS::Region
+
+  LogAuditLogGroup:
+    # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/frontend/audit
+      RetentionInDays: 14
+
+  FrontendLogsGroup:
+    # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub ${LogGroupPrefix}/${DeploymentName}/frontend
+      RetentionInDays: 14
+      DataProtectionPolicy:
+        Name: data-protection-policy-product-pages-frontend
+        Description: Data Protection for Cloudwatch Logs
+        Version: '2021-06-01'
+        Statement:
+          - Sid: audit-policy
+            DataIdentifier:
+              - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - arn:aws:dataprotection::aws:data-identifier/IpAddress
+              - arn:aws:dataprotection::aws:data-identifier/Address
+              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
+              - arn:aws:dataprotection::aws:data-identifier/OpenSshPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PuttyPrivateKey
+            Operation:
+              Audit:
+                FindingsDestination:
+                  CloudWatchLogs:
+                    LogGroup: !Ref LogAuditLogGroup
+          - Sid: redact-policy
+            DataIdentifier:
+              - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - arn:aws:dataprotection::aws:data-identifier/IpAddress
+              - arn:aws:dataprotection::aws:data-identifier/Address
+              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
+              - arn:aws:dataprotection::aws:data-identifier/OpenSshPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PuttyPrivateKey
+            Operation:
+              Deidentify:
+                MaskConfig: { }
 
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -146,13 +192,6 @@ Resources:
             Principal:
               Service: ecs-tasks.amazonaws.com
       Policies:
-        - PolicyName: CreateLogGroup
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action: logs:CreateLogGroup
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LogGroupPrefix}/${DeploymentName}/frontend*
         - PolicyName: GetDynatraceSecret
           PolicyDocument:
             Version: 2012-10-17


### PR DESCRIPTION
This PR aims to explicitly declare the LogGroups used by the core services in the stack and apply Data Protection Policies to each to redact PII, goes hand in hand with https://github.com/govuk-one-login/onboarding-self-service-experience/pull/591.

This includes separation of log groups **so that admin-tool and product pages don't share the same log groups** (and can therefore manage their own policies). This essentially means adding an additional application separator to the LogGroupPrefix, which changes from `/self-service` to `/self-service/[ product-pages | admin-tool ]`.