### PR TITLE
SSE-3135: Updated LB and TargetGroup name lengths

### DIFF
--- a/.github/workflows/deploy-component.yml
+++ b/.github/workflows/deploy-component.yml
@@ -39,7 +39,7 @@ jobs:
         uses: govuk-one-login/github-actions/beautify-branch-name@62863904d9aef239c1214f8e2d58577f38c9bb76 # 21/08/2023
         id: get-deployment-name
         with:
-          length-limit: 26
+          length-limit: 25
           prefix: preview
           verbose: false
 

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -15,7 +15,7 @@ Parameters:
     Default: /aws/vendedlogs
   DeploymentName:
     Type: String
-    MaxLength: 28
+    MaxLength: 25
     AllowedPattern: ^.*[^-]$
     Default: self-service
     Description: A unique prefix to identify the deployment; used when importing or exporting values from related stacks
@@ -233,7 +233,7 @@ Resources:
     Properties:
       Type: application
       Scheme: internet-facing
-      Name: !Sub ${DeploymentName}-app-productpage
+      Name: !Sub ${DeploymentName}-app-pp
       Subnets: !Split [ ",", !ImportValue VPC-InternetSubnets ]
       SecurityGroups: [ !Ref ApplicationSecurityGroup ]
       LoadBalancerAttributes:
@@ -261,7 +261,7 @@ Resources:
   ApplicationTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: !Sub ${DeploymentName}-ecs-productpage
+      Name: !Sub ${DeploymentName}-ecs-pp
       VpcId: !ImportValue VPC-ID
       Port: !Ref ContainerPort
       Protocol: HTTP


### PR DESCRIPTION
Because both Product Pages and Admin Tool share the same deployment config, some tickets can affect and require changes from both Github repositories. I've been running into hurdles using the same branch name for PRs from both repositories so would like the option to append a suffix to the branch name, but this currently breaks the length limits for product pages frontend stack. 

Looking to:

- Shorten the ${DeploymentName} to 25 characters.
- Shorten the suffix to 7 characters with -ecs-pp used as the suffix.