### PR TITLE
SSE-3150 & SSE-3110: Added log groups, removed LogGroupPrefix param

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -37,7 +37,6 @@ jobs:
       template: infrastructure/frontend/frontend.template.yml
       parameters: |
         ImageURI=${{ needs.push-frontend-image.outputs.image-uri }}
-        LogGroupPrefix=/self-service/preview
 
   run-acceptance-tests:
     name: Run tests

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -34,4 +34,3 @@ jobs:
       template: infrastructure/frontend/frontend.template.yml
       parameters: |
         ImageURI=${{ needs.push-frontend-image.outputs.image-uri }}
-        LogGroupPrefix=/self-service/preview

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -3,22 +3,29 @@ Description: DI Self-service Product Pages frontend
 Transform: AWS::LanguageExtensions
 
 Parameters:
+  Environment:
+    Description: "The name of the environment to deploy to."
+    Type: "String"
+    Default: local
+    AllowedValues:
+      - "local"
+      - "dev"
+      - "build"
+      - "staging"
+      - "integration"
+      - "production"
+  DeploymentName:
+    Type: String
+    MaxLength: 22
+    AllowedPattern: ^.*[^-]$
+    Default: self-service
+    Description: A unique prefix to identify the deployment; used to distinguish variation between ephemeral stacks
   ImageURI:
     Type: String
     Description: The URI of the ECR image to use for the container
   ContainerPort:
     Type: Number
     Default: 3000
-  LogGroupPrefix:
-    Type: String
-    AllowedPattern: ^.*[^\/]$
-    Default: /aws/vendedlogs
-  DeploymentName:
-    Type: String
-    MaxLength: 25
-    AllowedPattern: ^.*[^-]$
-    Default: self-service
-    Description: A unique prefix to identify the deployment; used when importing or exporting values from related stacks
   ShowTestBanner:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /product-pages/frontend/show-test-banner
@@ -29,24 +36,42 @@ Parameters:
     Type: String
     Default: ""
     Description: The ARN of the permissions boundary to apply when creating IAM roles
-  Environment:
-    Description: "The name of the environment to deploy to."
-    Type: "String"
-    Default: dev
-    AllowedValues:
-      - "dev"
-      - "build"
-      - "staging"
-      - "integration"
-      - "production"
+
+Rules:
+  DeploymentNameRequired:
+    RuleCondition: !Equals [ !Ref Environment, "local" ]
+    Assertions:
+      - Assert: !Not [ !Equals [ !Ref DeploymentName, "" ] ]
+        AssertDescription: >
+          Must specify DeploymentName parameter when Environment is "local"
+  DeploymentNameMustBeEmpty:
+    RuleCondition: !Not [ !Equals [ !Ref Environment, "local" ] ]
+    Assertions:
+      - Assert: !Equals [ !Ref DeploymentName, "self-service" ] # Confirm the default value is used.
+        AssertDescription: >
+          Must not specify DeploymentName parameter when Environment is not "local"
 
 Mappings:
+  EnvironmentConfiguration:
+    local:
+      logGroupPrefix: /self-service/product-pages/frontend
+    dev:
+      logGroupPrefix: /self-service/product-pages/frontend
+    build:
+      logGroupPrefix: /self-service/product-pages/frontend
+    staging:
+      logGroupPrefix: /self-service/product-pages/frontend
+    integration:
+      logGroupPrefix: /self-service/product-pages/frontend
+    production:
+      logGroupPrefix: /self-service/product-pages/frontend
   # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancer:
     eu-west-2:
       AccountID: 652711504416
   TxMAAccountARN:
     Environment:
+      local: 'arn:aws:iam::494650018671:root'
       dev: 'arn:aws:iam::494650018671:root'
       build: 'arn:aws:iam::399055180839:root'
       staging: 'arn:aws:iam::178023842775:root'
@@ -57,6 +82,7 @@ Conditions:
   Subdomain: !Not [ !Equals [ !Ref DeploymentName, self-service ] ]
   NonDevEnv: !Equals [ !Ref DeploymentName, self-service ]
   UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundary, "" ] ]
+  IsLocal: !Equals [ !Ref Environment, "local" ]
 
 Resources:
 
@@ -127,10 +153,64 @@ Resources:
             Options:
               # Consider lines not starting with whitespace as a multi-line log message boundary
               awslogs-multiline-pattern: ^[^\s}]+.*$
-              awslogs-group: !Sub ${LogGroupPrefix}/${DeploymentName}/frontend
+              awslogs-group: !Ref FrontendLogsGroup
               awslogs-stream-prefix: ecs
-              awslogs-create-group: true
               awslogs-region: !Ref AWS::Region
+
+  LogAuditLogGroup:
+    # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join
+        - "/"
+        - - !FindInMap [ EnvironmentConfiguration, !Ref Environment, logGroupPrefix ]
+          - !If [ IsLocal, !Ref DeploymentName, !Ref AWS::NoValue ]
+          - 'audit'
+      RetentionInDays: 14
+
+  FrontendLogsGroup:
+    # checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join
+        - "/"
+        - - !FindInMap [ EnvironmentConfiguration, !Ref Environment, logGroupPrefix ]
+          - !If [ IsLocal, !Ref DeploymentName, !Ref AWS::NoValue ]
+          - 'ecr'
+      RetentionInDays: 14
+      DataProtectionPolicy:
+        Name: data-protection-policy-frontend
+        Description: Data Protection for Cloudwatch Logs
+        Version: '2021-06-01'
+        Statement:
+          - Sid: audit-policy
+            DataIdentifier:
+              - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - arn:aws:dataprotection::aws:data-identifier/IpAddress
+              - arn:aws:dataprotection::aws:data-identifier/Address
+              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
+              - arn:aws:dataprotection::aws:data-identifier/OpenSshPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PuttyPrivateKey
+            Operation:
+              Audit:
+                FindingsDestination:
+                  CloudWatchLogs:
+                    LogGroup: !Ref LogAuditLogGroup
+          - Sid: redact-policy
+            DataIdentifier:
+              - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - arn:aws:dataprotection::aws:data-identifier/IpAddress
+              - arn:aws:dataprotection::aws:data-identifier/Address
+              - arn:aws:dataprotection::aws:data-identifier/AwsSecretKey
+              - arn:aws:dataprotection::aws:data-identifier/OpenSshPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PgpPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PkcsPrivateKey
+              - arn:aws:dataprotection::aws:data-identifier/PuttyPrivateKey
+            Operation:
+              Deidentify:
+                MaskConfig: { }
 
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -146,13 +226,6 @@ Resources:
             Principal:
               Service: ecs-tasks.amazonaws.com
       Policies:
-        - PolicyName: CreateLogGroup
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action: logs:CreateLogGroup
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LogGroupPrefix}/${DeploymentName}/frontend*
         - PolicyName: GetDynatraceSecret
           PolicyDocument:
             Version: 2012-10-17


### PR DESCRIPTION
This PR aims to explicitly declare the LogGroups used by the core services in the stack and apply Data Protection Policies to each to redact PII, goes hand in hand with https://github.com/govuk-one-login/onboarding-self-service-experience/pull/591.

This includes separation of log groups **so that admin-tool and product pages don't share the same log groups** (and can therefore manage their own policies). This essentially means adding an additional application separator to the LogGroupPrefix, which changes from `/self-service` to `/self-service/[ product-pages | admin-tool ]`.

It also includes removal of the `LogGroupPrefix` parameter which set default values which cannot be changed in secure pipelines environments.

This supersedes https://github.com/govuk-one-login/onboarding-product-page/pull/276