### PR TITLE
SSE-3170:Turned on ECS Container ReadonlyFilesystem (i.e. set to True)

### DIFF
--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -88,7 +88,7 @@ Resources:
       ContainerDefinitions:
         - Name: productpage-frontend
           Image: !Ref ImageURI
-          ReadonlyRootFilesystem: false
+          ReadonlyRootFilesystem: true
           Environment:
             - Name: PORT
               Value: !Ref ContainerPort


### PR DESCRIPTION
Sub-Task for SSE-3095.

The Flag readonlyRootFilesystem in the Product Pages Template Definition File is currently set to False which is causing a High Severity Record to be reported in Security Hub - This should be set as per the instructions in [Amazon ECS controls - AWS Security Hub](https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html) (ECS.5).

This issue was also highlighted for Admin Portal but a ticket had been raised previously and the issue has been fixed in that system.