### PR TITLE
SSE-3170: Turned on ECS Container ReadonlyFilesystem

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Hidden files & directories
+.github
+.idea
+
+# Dependencies build as required
+node_modules/
+jspm_packages/
+
+# Test & infrastructure files
+infrastructure/
+monitoring/
+ci/
+test/
+features/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,27 +4,30 @@
 # Use an official Node.js runtime as a parent image
 FROM node:latest
 
+# Expose any necessary ports (if your application requires it)
+ARG PORT=3000
+ENV PORT=$PORT
+EXPOSE $PORT
+
 # Set the working directory in the container
 WORKDIR /app
 
-# Copy the package.json and package-lock.json files to the container
-COPY *.json ./
+# Copy the application code, see .dockerignore for exclusions
+COPY . .
+
+# Copy the .env.example file to .env @TODO questionable at best
+COPY .env.example .env
 
 # Install project dependencies
 ENV PUPPETEER_SKIP_DOWNLOAD true
 RUN apt-get update && apt-get install -y chromium
-RUN npm install
+RUN npm install && npm run build
 
-# Copy the .env.example file to .env
-COPY .env.example .env
-
-# Copy the rest of your application code to the container
-COPY . .
+# Add the Dynatrace OneAgent
 COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
 ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
-# Expose any necessary ports (if your application requires it)
-# EXPOSE 3000
+USER node
+CMD npm start
 
-# Define the command to run your application
-CMD [ "npm", "run", "local" ]
+HEALTHCHECK CMD wget --spider http://localhost:$PORT

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -4,25 +4,26 @@
 # Use an official Node.js runtime as a parent image
 FROM node:latest
 
+# Expose any necessary ports (if your application requires it)
+ARG PORT=3000
+ENV PORT=$PORT
+EXPOSE $PORT
+
 # Set the working directory in the container
 WORKDIR /app
 
-# Copy the package.json and package-lock.json files to the container
-COPY *.json ./
+# Copy the application code, see .dockerignore for exclusions
+COPY . .
+
+# Copy the .env.example file to .env @TODO questionable at best
+COPY .env.example .env
 
 # Install project dependencies
 ENV PUPPETEER_SKIP_DOWNLOAD true
 RUN apt-get update && apt-get install -y chromium
-RUN npm install
+RUN npm install && npm run build
 
-# Copy the .env.example file to .env
-COPY .env.example .env
+USER node
+CMD npm start
 
-# Copy the rest of your application code to the container
-COPY . .
-
-# Expose any necessary ports (if your application requires it)
-# EXPOSE 3000
-
-# Define the command to run your application
-CMD [ "npm", "run", "local" ]
+HEALTHCHECK CMD wget --spider http://localhost:$PORT

--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -114,7 +114,7 @@ Resources:
       ContainerDefinitions:
         - Name: productpage-frontend
           Image: !Ref ImageURI
-          ReadonlyRootFilesystem: false
+          ReadonlyRootFilesystem: true
           Environment:
             - Name: PORT
               Value: !Ref ContainerPort


### PR DESCRIPTION
Sub-Task for [SSE-3095](https://govukverify.atlassian.net/browse/SSE-3095).

The Flag readonlyRootFilesystem in the Product Pages Template Definition File is currently set to False which is causing a High Severity Record to be reported in Security Hub - This should be set as per the instructions in [Amazon ECS controls - AWS Security Hub](https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html) (ECS.5).

This issue was also highlighted for Admin Portal but a ticket had been raised previously and the issue has been fixed in that system.

The docker file runs `npm run local` as a startup command, but should run `npm start`. Any install or build commands should run while the image is being built, not as CMD.

[SSE-3095]: https://govukverify.atlassian.net/browse/SSE-3095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ