### PR TITLE
SSE-3196 Add digital.hmrc.gov.uk domain to allowed email domains list

### DIFF
--- a/resources/allowed-email-domains.txt
+++ b/resources/allowed-email-domains.txt
@@ -2002,3 +2002,4 @@ digital.mod.uk
 digital.trade.gov.uk
 digital.homeoffice.gov.uk
 levellingup.gov.uk
+digital.hmrc.gov.uk


### PR DESCRIPTION
Add digital.hmrc.gov.uk domain to allowed email domains list