### PR TITLE
SSE-3238 - Set WAF rule action to count

### DIFF
--- a/infrastructure/frontend/frontend.template.yml
+++ b/infrastructure/frontend/frontend.template.yml
@@ -504,7 +504,7 @@ Resources:
                 VendorName: AWS
                 Name: AWSManagedRulesAnonymousIpList
             OverrideAction:
-              None: { }
+              Count: { }
             VisibilityConfig:
               SampledRequestsEnabled: true
               CloudWatchMetricsEnabled: true


### PR DESCRIPTION
# Code Changes
- set AWSManagedRulesAnonymousIpList rule action to count

# Why
- Deploy the WAF policies in COUNT mode
- No traffic should be blocked by the WAF
- https://govukverify.atlassian.net/browse/INCIDEN-700