### PR TITLE
SSE-3272: add energysecurity.gov.uk to the email domain allow list

### DIFF
--- a/resources/allowed-email-domains.txt
+++ b/resources/allowed-email-domains.txt
@@ -2007,3 +2007,4 @@ osic.gov.uk
 llyw.cymru
 businesstrade.gov.uk
 Socialworkengland.gov.uk
+energysecurity.gov.uk


### PR DESCRIPTION
- enable people using the energysecurity.gov.uk email domain to register their interest

https://govukverify.atlassian.net/browse/SSE-3272