### PR TITLE
BAU: bumps express to v 4.19.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@govuk-one-login/one-login-analytics": "^0.0.9",
         "axios": "^1.6.2",
         "email-validator": "^2.0.4",
-        "express": "^4.18.2",
+        "express": "^4.19.2",
         "google-auth-library": "^8.5.2",
         "googleapis": "^91.0.0",
         "govuk-frontend": "^4.8.0",
@@ -2453,9 +2453,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3102,16 +3102,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
-      "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@govuk-one-login/one-login-analytics": "^0.0.9",
     "axios": "^1.6.2",
     "email-validator": "^2.0.4",
-    "express": "^4.18.2",
+    "express": "^4.19.2",
     "google-auth-library": "^8.5.2",
     "googleapis": "^91.0.0",
     "govuk-frontend": "^4.8.0",


### PR DESCRIPTION
## BAU: Bump express to version 4.19.2
### This PR Adds:
 - N/A
### This PR Modifies:
- Bumps express to version 4.19.2, as older versions of express have a vulnerability when using `res.redirect()`
https://github.com/advisories/GHSA-rv95-896h-c2vc

### This PR Removes:
- N/A


