### PR TITLE
BAU: Prevent concurrent deploys to the same environment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -37,6 +37,8 @@ jobs:
     if: github.event_name == 'merge_group'
     needs: [ build ]
     runs-on: ubuntu-latest
+    concurrency:
+      group: dev-deploy
     timeout-minutes: 20
     environment:
       name: development

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -32,6 +32,8 @@ jobs:
     name: Push prod
     needs: [ build ]
     runs-on: ubuntu-latest
+    concurrency:
+      group: prod-deploy
     timeout-minutes: 20
     environment:
       name: build


### PR DESCRIPTION
In the merge queue we try to deploy to dev. Without concurrency protection on the deployment, it's only safe to run one set of checks at a time, which is slow. For production, concurrent deployments will succeed in AWS, but show as failed in github