### PR TITLE
OLH-2209: Update documentation-let-users-navigate.njk

### DIFF
--- a/src/views/documentation-let-users-navigate.njk
+++ b/src/views/documentation-let-users-navigate.njk
@@ -15,8 +15,8 @@
 {% block mainContent %}
   <h1 class="govuk-heading-l">Let users navigate to their GOV.UK One Login and sign out easily</h1>
   <h2 class="govuk-heading-m">What is it?</h2>
-  <p class="govuk-body">The GOV.UK One Login service header is a new version of the <a class="govuk-link" href="https://design-system.service.gov.uk/components/header/">GOV.UK header</a>. It’s for services using GOV.UK One Login.</p>
-  <p class="govuk-body">The header gives users an easy, consistent route from your service to their GOV.UK One Login and a way to sign out.</p>
+  <p class="govuk-body">The GOV.UK One Login service header gives users an easy, consistent route from your service to their GOV.UK One Login and a way to sign out.</p>
+  <p class="govuk-body">It’s different to the GOV.UK header and service navigation components from the GOV.UK Design System.</p>
   <p class="govuk-body">When signed in, users can navigate to their GOV.UK One Login easily so they can access the services they use with it and also change their sign in details.</p>
   <h2 class="govuk-heading-m">When to use it</h2>
   <p class="govuk-body">You should use this pattern if your service is using GOV.UK One Login.</p>


### PR DESCRIPTION
Update design recommendation guidance for using the One Login Header component. This is in response to the new Design System service navigation component being launched as part of v5.6.0.

JIRA: https://govukverify.atlassian.net/browse/OLH-2209

# Onboarding Feature Deployment

> [!WARNING]
> Pull requests merged to `main` will be released to production, please ensure the checklist below is complete

Before any work can be merged to main in must meet the definition of done and be ready to deploy. While many of these tasks will be automated, the reviewers must take the responsibility of confirming the checklist below has been completed before this ticket can be merged.

## Checklist

-   [ ] this pull request meets the acceptance criteria of the ticket
-   [ ] this branch is up-to-date with the main branch

    `git fetch --all && git rebase origin/main`

-   [ ] these changes are backwards compatible (no breaking changes)

-   all methods signatures and return values are the same
-   any replaced methods are marked as `@deprecated`

-   [ ] tests have been written to cover any new or updated functionality

-   [ ] new configuration parameters have been deployed to all environments, see [configuration management](https://govukverify.atlassian.net/l/cp/N7q3Vh3r).

-   [ ] all external infrastructure dependencies have been updated in all environments

## Changes

[ _please list the changes this pull request is making_ ]



### `Changed` content on [Let users navigate to their GOV.UK One Login and sign out easily](https://www.sign-in.service.gov.uk/documentation/design-recommendations/let-users-navigate-sign-out)

