### PR TITLE
ATO-1619 Improve grouping of updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
         applies-to: version-updates
         dependency-type: "production"
         update-types:
-          - "minor"
           - "patch"
   - package-ecosystem: npm
     directory: /ui-automation-tests
@@ -30,8 +29,9 @@ updates:
     groups:
       test-dependencies:
         applies-to: version-updates
-        patterns:
-          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -44,8 +44,9 @@ updates:
     groups:
       gha-dependencies:
         applies-to: version-updates
-        patterns:
-          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: docker
     directory: /
     schedule:
@@ -58,5 +59,6 @@ updates:
     groups:
       docker-dependencies:
         applies-to: version-updates
-        patterns:
-          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Context: the current dependabot configuration is grouping multiple updates in such a way that there is a risk that a breaking change in one update will delay approval of multiple updates. It makes sense to group updates only where there is a strong likelihood that the update can be approved without any manual changes or manual testing.
- for prod dependencies, only group patch updates
- for test, docker and github action dependencies, group minor and patch updates