### PR TITLE
ATO-1619 - Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,17 @@ updates:
         dependency-type: "production"
         update-types:
           - "patch"
+      dev-dependencies:
+        applies-to: version-updates
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "@govuk-frontend"
+        update-types: [ "version-update:semver-major" ]
   - package-ecosystem: npm
     directory: /ui-automation-tests
     schedule:


### PR DESCRIPTION
- Group minor and patch updates for dev dependencies to improve efficiency
- Ignore major version bumps for node and frontend (these are well-publicised so we don't need a dependabot reminder, they may require significant work and we will determine when is best to update them)