### PR TITLE
BAU - bump node to 20.19.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a slim lts-supported version.
-FROM node:20.16.0-alpine3.20@sha256:eb8101caae9ac02229bd64c024919fe3d4504ff7f329da79ca60a04db08cef52 AS production
+FROM node:20.19.2-alpine3.20@sha256:3bc9a4c4cc25cfde1e8f946341c85f333c36517aafda829b4bb7e785e9b5995c AS production
 
 # Expose any necessary ports (if your application requires it)
 ARG PORT=3000


### PR DESCRIPTION
Bump node to patch vulnerabilities as per [changelog](https://github.com/nodejs/node/releases/tag/v20.19.2).

Tested by deploying to dev preview, logs show correct node version:

<img width="1130" alt="Screenshot 2025-05-16 at 14 41 15" src="https://github.com/user-attachments/assets/733420e4-99c6-4557-bfd9-97ab2e13b70f" />

And home page looks good:

<img width="1206" alt="Screenshot 2025-05-16 at 14 30 09" src="https://github.com/user-attachments/assets/2d8e0435-cb5e-4288-a471-8a8f15a1177d" />
