### PR TITLE
BAU: Fix tests by installing chrome

### DIFF
--- a/ui-automation-tests/package.json
+++ b/ui-automation-tests/package.json
@@ -2,8 +2,8 @@
   "name": "gds-di-product-page-ui-automation-tests",
   "description": "DI Product pages UI Automations tests",
   "scripts": {
-    "acceptance-tests": "cucumber-js acceptance-features",
-    "accessibility-tests": "cucumber-js accessibility-features"
+    "acceptance-tests": "npx puppeteer browsers install chrome && cucumber-js acceptance-features",
+    "accessibility-tests": "npx puppeteer browsers install chrome && cucumber-js accessibility-features"
   },
   "devDependencies": {
     "@axe-core/puppeteer": "^4.10.2",


### PR DESCRIPTION
# Onboarding Feature Deployment

We seem to be getting an error when running these tests locally and in the pipeline where it cannot find the right version of chrome:

```
[cause]: Error: Could not find Chrome (ver. 143.0.7499.169). This can occur if either
   1. you did not perform an installation before running the script (e.g. `npx puppeteer browsers install chrome`) or
   2. your cache path is incorrectly configured (which is: /app/.cache/puppeteer).
```

Not sure why this is suddently a problem, but it means the tests fail to start because the browser does not launch. We can fix this by applying the first bullet point before running the tests and using puppeteer to install chrome before we run the tests

## Checklist

- [ ] this pull request meets the acceptance criteria of the ticket
- [ ] this branch is up-to-date with the main branch

    `git fetch --all && git rebase origin/main`

- [ ] these changes are backwards compatible (no breaking changes)

- all methods signatures and return values are the same
- any replaced methods are marked as `@deprecated`

- [ ] tests have been written to cover any new or updated functionality

- [ ] new configuration parameters have been deployed to all environments, see [configuration management](https://govukverify.atlassian.net/l/cp/N7q3Vh3r).

- [ ] all external infrastructure dependencies have been updated in all environments

## Changes

[ _please list the changes this pull request is making_ ]

### `Added` for new features

### `Changed` for changes in existing functionality

### `Deprecated` for soon-to-be removed features

### `Removed` for now removed features

### `Fixed` for any bug fixes

### `Security` in case of vulnerabilities
