### PR TITLE
BAU: Add dependabot exclusion for mocha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,8 @@ updates:
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "@govuk-frontend"
         update-types: [ "version-update:semver-major" ]
+      - dependency-name: "mocha"
+        update-types: "^11.3.0"
   - package-ecosystem: npm
     directory: /ui-automation-tests
     schedule:


### PR DESCRIPTION
Mocha versions above 11.3.0 include a dependency with a vulnerability. Mocha v12 will remove this dependency but its in beta at the moment so once its officially released dependabot can update us to it!