### PR TITLE
BAU: Add composite actions to dependabot config

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Pull repository
       id: checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Install Node
       id: node

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,7 +50,9 @@ updates:
           - "minor"
           - "patch"
   - package-ecosystem: github-actions
-    directory: /
+    directories: 
+      - /
+      - /.github/**
     schedule:
       interval: daily
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,7 @@ updates:
       - dependency-name: "@govuk-frontend"
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "mocha"
-        update-types: "^11.3.0"
+        versions: [ "^11.3.0" ]
   - package-ecosystem: npm
     directory: /ui-automation-tests
     schedule:


### PR DESCRIPTION
Previously, the build and push composite actions were not included by dependabot. This is because by default dependabot only looks in `.github/workflows` and doesn't include subdirectories. This lead to the checkout action being updated for all workflows but the build action.

This PR adds the build and push GHA directories to the dependabot config so hopefully this doesn't happen again
It also updates the build action to set the checkout version to match everywhere else