### PR TITLE
BAU: Increase cucumber default timeout

### DIFF
--- a/ui-automation-tests/support/steps/shared-functions.ts
+++ b/ui-automation-tests/support/steps/shared-functions.ts
@@ -1,7 +1,7 @@
 import {strict as assert} from "assert";
 import {ElementHandle, Page} from "puppeteer";
 
-const defaultTimeout = 5000;
+const defaultTimeout = 10000;
 // eslint-disable-next-line
 export async function getLink(page: Page, linkText: string): Promise<any> {
     const links = await page.$$(`::-p-xpath(//a[text()="${linkText}"])`);

--- a/ui-automation-tests/support/test-setup.ts
+++ b/ui-automation-tests/support/test-setup.ts
@@ -1,8 +1,10 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-import {World, After, AfterAll, Before, BeforeAll, setWorldConstructor} from "@cucumber/cucumber";
+import {World, After, AfterAll, Before, BeforeAll, setDefaultTimeout, setWorldConstructor} from "@cucumber/cucumber";
 import {IWorldOptions} from "@cucumber/cucumber/lib/support_code_library_builder/world";
 import puppeteer, {Browser, Page} from "puppeteer";
 import fse from "fs-extra";
+
+setDefaultTimeout(10 * 1000);
 
 let browser: Browser, counter: number;
 


### PR DESCRIPTION
The tests were timing out in the pipeline, this should help mitigate that